### PR TITLE
Fix multiline YAML value encryption and add Encryption menu

### DIFF
--- a/src/main/java/com/dataliquid/passwordsuite/service/EditorService.java
+++ b/src/main/java/com/dataliquid/passwordsuite/service/EditorService.java
@@ -1,7 +1,9 @@
 package com.dataliquid.passwordsuite.service;
 
 import java.util.ArrayDeque;
+import java.util.ArrayList;
 import java.util.Deque;
+import java.util.List;
 import java.util.regex.Pattern;
 
 import javax.swing.JTextArea;
@@ -23,6 +25,8 @@ import com.dataliquid.passwordsuite.parser.ParserFactory;
 public class EditorService {
 
     private static final Logger logger = LoggerFactory.getLogger(EditorService.class);
+    private static final char TAB_CHAR = '\t';
+    private static final int TAB_WIDTH = 4;
 
     private ConfigTree currentTree;
     private final Deque<Operation> undoStack = new ArrayDeque<>();
@@ -146,6 +150,7 @@ public class EditorService {
     /**
      * Replaces a value in the editor text at the exact line where the ConfigEntry
      * is located. This preserves comments, whitespace, and all other formatting.
+     * Supports both single-line and multiline YAML values (literal block scalar).
      *
      * @param entry    the ConfigEntry containing lineNumber and key info
      * @param oldValue the old value to replace
@@ -175,18 +180,25 @@ public class EditorService {
             return;
         }
 
-        String originalLine = lines[lineNum];
-        String newLine = replaceValueInLine(originalLine, oldValue, newValue);
+        String newContent;
 
-        if (newLine.equals(originalLine)) {
-            if (logger.isWarnEnabled()) {
-                logger.warn("Value not found in line {} for replacement (key={})", lineNum, entry.getKey());
+        // Check if this is a multiline value (contains newlines)
+        if (oldValue.contains("\n")) {
+            newContent = replaceMultilineValue(lines, lineNum, entry.getKey(), newValue);
+        } else {
+            String originalLine = lines[lineNum];
+            String newLine = replaceValueInLine(originalLine, oldValue, newValue);
+
+            if (newLine.equals(originalLine)) {
+                if (logger.isWarnEnabled()) {
+                    logger.warn("Value not found in line {} for replacement (key={})", lineNum, entry.getKey());
+                }
+                return;
             }
-            return;
-        }
 
-        lines[lineNum] = newLine;
-        String newContent = String.join("\n", lines);
+            lines[lineNum] = newLine;
+            newContent = String.join("\n", lines);
+        }
 
         // Update editor while preserving cursor position
         int caretPos = editor.getCaretPosition();
@@ -200,6 +212,100 @@ public class EditorService {
         if (logger.isInfoEnabled()) {
             logger.info("Replaced value in editor at line {} (key={})", lineNum, entry.getKey());
         }
+    }
+
+    /**
+     * Replaces a multiline YAML value (literal block scalar with | or >) with a
+     * single-line value. Removes all indented continuation lines.
+     *
+     * @param  lines    the lines of the document
+     * @param  lineNum  the line number of the key
+     * @param  key      the key name
+     * @param  newValue the new value to insert
+     *
+     * @return          the new content with the multiline value replaced
+     */
+    private String replaceMultilineValue(String[] lines, int lineNum, String key, String newValue) {
+        String keyLine = lines[lineNum];
+        int keyIndent = getIndentation(keyLine);
+
+        // Build new key line: preserve indentation, replace "key: |" or "key: >" with
+        // "key: newValue"
+        String trimmedKeyLine = keyLine.trim();
+        String newKeyLine;
+        if (trimmedKeyLine.endsWith("|") || trimmedKeyLine.endsWith(">")) {
+            // Replace the block scalar indicator with the new value
+            int colonPos = keyLine.indexOf(':');
+            newKeyLine = keyLine.substring(0, colonPos + 1) + " " + newValue;
+        } else {
+            // Fallback: just use key: newValue with same indentation
+            newKeyLine = " ".repeat(keyIndent) + key + ": " + newValue;
+        }
+
+        // Collect lines, skipping the multiline block content
+        List<String> resultLines = new ArrayList<>();
+        boolean blockEnded = false;
+
+        for (int i = 0; i < lines.length; i++) {
+            if (i == lineNum) {
+                resultLines.add(newKeyLine);
+            } else if (i > lineNum && !blockEnded) {
+                // Skip lines that are part of the multiline block (more indented than key)
+                int lineIndent = getIndentation(lines[i]);
+                boolean isEmptyOrWhitespace = lines[i].isBlank();
+
+                if (isEmptyOrWhitespace) {
+                    // Empty line - check if still within block
+                    if (isWithinMultilineBlock(lines, i, keyIndent)) {
+                        continue; // Skip empty line within block
+                    } else {
+                        blockEnded = true;
+                        resultLines.add(lines[i]);
+                    }
+                } else if (lineIndent > keyIndent) {
+                    continue; // Skip this line (part of multiline block)
+                } else {
+                    // Line with same or less indentation - block has ended
+                    blockEnded = true;
+                    resultLines.add(lines[i]);
+                }
+            } else {
+                resultLines.add(lines[i]);
+            }
+        }
+
+        return String.join("\n", resultLines);
+    }
+
+    /**
+     * Checks if an empty line at the given index is within a multiline block.
+     */
+    private boolean isWithinMultilineBlock(String[] lines, int index, int keyIndent) {
+        // Look ahead to see if there are more indented lines after this empty line
+        for (int i = index + 1; i < lines.length; i++) {
+            String line = lines[i];
+            if (!line.isBlank()) {
+                return getIndentation(line) > keyIndent;
+            }
+        }
+        return false;
+    }
+
+    /**
+     * Returns the number of leading spaces in a line. Tabs are counted as 4 spaces.
+     */
+    private int getIndentation(String line) {
+        int count = 0;
+        for (char c : line.toCharArray()) {
+            if (Character.isSpaceChar(c)) {
+                count++;
+            } else if (c == TAB_CHAR) {
+                count += TAB_WIDTH;
+            } else {
+                break;
+            }
+        }
+        return count;
     }
 
     /**

--- a/src/main/java/com/dataliquid/passwordsuite/ui/MainFrame.java
+++ b/src/main/java/com/dataliquid/passwordsuite/ui/MainFrame.java
@@ -215,6 +215,30 @@ public final class MainFrame extends JFrame {
         editMenu.add(createMenuItem("Undo", 'U', e -> editHandler.handleUndo()));
         editMenu.add(createMenuItem("Redo", 'R', e -> editHandler.handleRedo()));
 
+        editMenu.addSeparator();
+
+        // Encryption submenu
+        JMenu encryptionMenu = new JMenu("Encryption");
+        encryptionMenu.setMnemonic('n');
+
+        JMenuItem encryptMarkedItem = createMenuItem("Encrypt Marked", 'E',
+                e -> cryptoHandler
+                        .handleEncryptMarked(tabbedEditorPanel.getActiveTab(), treePanel, treePanel::refresh,
+                                this::showError, this::showInfo));
+        encryptMarkedItem
+                .setAccelerator(KeyStroke.getKeyStroke(KeyEvent.VK_E, shortcutKey | InputEvent.SHIFT_DOWN_MASK));
+        encryptionMenu.add(encryptMarkedItem);
+
+        JMenuItem decryptMarkedItem = createMenuItem("Decrypt Marked", 'D',
+                e -> cryptoHandler
+                        .handleDecryptMarked(tabbedEditorPanel.getActiveTab(), treePanel, treePanel::refresh,
+                                this::showError, this::showInfo));
+        decryptMarkedItem
+                .setAccelerator(KeyStroke.getKeyStroke(KeyEvent.VK_D, shortcutKey | InputEvent.SHIFT_DOWN_MASK));
+        encryptionMenu.add(decryptMarkedItem);
+
+        editMenu.add(encryptionMenu);
+
         // Settings Menu - delegate to EnvironmentsHandler
         JMenu settingsMenu = new JMenu("Settings");
         settingsMenu.setMnemonic('S');

--- a/src/main/java/com/dataliquid/passwordsuite/ui/handler/EnvironmentsHandler.java
+++ b/src/main/java/com/dataliquid/passwordsuite/ui/handler/EnvironmentsHandler.java
@@ -147,7 +147,6 @@ public class EnvironmentsHandler {
     /**
      * Handles algorithm selection change.
      */
-    @SuppressWarnings("PMD.InvalidLogMessageFormat")
     public void handleAlgorithmChange() {
         FileTab activeTab = tabbedEditorPanel.getActiveTab();
         if (activeTab != null) {
@@ -170,7 +169,7 @@ public class EnvironmentsHandler {
                 }
             } catch (CryptoException e) {
                 if (logger.isErrorEnabled()) {
-                    logger.error("Failed to switch algorithm to: {} - {}", selected, e.getMessage(), e);
+                    logger.error("Failed to switch algorithm to: " + selected, e);
                 }
                 JOptionPane
                         .showMessageDialog(parentFrame, "Failed to switch algorithm: " + e.getMessage(),
@@ -182,7 +181,6 @@ public class EnvironmentsHandler {
     /**
      * Handles environment selection change.
      */
-    @SuppressWarnings("PMD.InvalidLogMessageFormat")
     public void handleEnvironmentChange() {
         String selected = actionPanel.getSelectedEnvironment();
         logger.debug("Environment change requested: {}", selected);
@@ -196,9 +194,7 @@ public class EnvironmentsHandler {
                 updateCryptoServicePassword();
             } catch (CryptoException e) {
                 if (logger.isErrorEnabled()) {
-                    logger
-                            .error("Failed to update CryptoService for environment: {} - {}", selected, e.getMessage(),
-                                    e);
+                    logger.error("Failed to update CryptoService for environment: " + selected, e);
                 }
             }
         }
@@ -211,7 +207,7 @@ public class EnvironmentsHandler {
                 cryptoService.setAlgorithm(defaultAlgorithm);
             } catch (CryptoException e) {
                 if (logger.isErrorEnabled()) {
-                    logger.error("Failed to set default algorithm: {} - {}", defaultAlgorithm, e.getMessage(), e);
+                    logger.error("Failed to set default algorithm: " + defaultAlgorithm, e);
                 }
             }
         } else {

--- a/src/test/java/com/dataliquid/passwordsuite/service/EditorServiceTest.java
+++ b/src/test/java/com/dataliquid/passwordsuite/service/EditorServiceTest.java
@@ -3,6 +3,8 @@ package com.dataliquid.passwordsuite.service;
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.assertThatThrownBy;
 
+import javax.swing.JTextArea;
+
 import org.junit.jupiter.api.Test;
 
 import com.dataliquid.passwordsuite.domain.ConfigEntry;
@@ -126,5 +128,94 @@ class EditorServiceTest {
 
         service.redo();
         assertThat(entry.getValue()).isEqualTo("value3");
+    }
+
+    @Test
+    void shouldReplaceMultilineYamlValue() throws ParseException {
+        String yaml = """
+                gcp:
+                  project_id: my-project-12345
+                  service_account_key: |
+                    {
+                      "type": "service_account",
+                      "project_id": "my-project-12345",
+                      "private_key": "-----BEGIN PRIVATE KEY-----"
+                    }
+                  other_key: value
+                """;
+
+        service.parseContent(yaml);
+        ConfigEntry entry = (ConfigEntry) service.getCurrentTree().findByPath("gcp.service_account_key").orElseThrow();
+
+        String oldValue = entry.getValue();
+        String newValue = "ENC[encrypted_multiline_value]";
+
+        JTextArea editor = new JTextArea(yaml);
+        service.replaceValueInEditor(entry, oldValue, newValue, editor);
+
+        String result = editor.getText();
+
+        // The multiline value should be replaced with the single-line encrypted value
+        assertThat(result).contains("service_account_key: ENC[encrypted_multiline_value]");
+        assertThat(result).doesNotContain("\"type\": \"service_account\"");
+        assertThat(result).doesNotContain("\"private_key\"");
+        // Other entries should remain unchanged
+        assertThat(result).contains("project_id: my-project-12345");
+        assertThat(result).contains("other_key: value");
+    }
+
+    @Test
+    void shouldReplaceSingleLineValue() throws ParseException {
+        String yaml = "host: localhost\nport: 5432";
+
+        service.parseContent(yaml);
+        ConfigEntry entry = (ConfigEntry) service.getCurrentTree().findByPath("host").orElseThrow();
+
+        JTextArea editor = new JTextArea(yaml);
+        service.replaceValueInEditor(entry, "localhost", "ENC[encrypted]", editor);
+
+        assertThat(editor.getText()).isEqualTo("host: ENC[encrypted]\nport: 5432");
+    }
+
+    @Test
+    void shouldPreserveEntriesAfterMultilineBlock() throws ParseException {
+        String yaml = """
+                gcp:
+                  project_id: my-project-12345
+                  service_account_key: |
+                    {
+                      "type": "service_account"
+                    }
+
+                external_apis:
+                  stripe:
+                    public_key: pk_test_123
+                    secret_key: sk_test_456
+                  twilio:
+                    account_sid: AC123
+                """;
+
+        service.parseContent(yaml);
+        ConfigEntry entry = (ConfigEntry) service.getCurrentTree().findByPath("gcp.service_account_key").orElseThrow();
+
+        String oldValue = entry.getValue();
+        String newValue = "ENC[encrypted]";
+
+        JTextArea editor = new JTextArea(yaml);
+        service.replaceValueInEditor(entry, oldValue, newValue, editor);
+
+        String result = editor.getText();
+
+        // Multiline block should be replaced
+        assertThat(result).contains("service_account_key: ENC[encrypted]");
+        assertThat(result).doesNotContain("\"type\": \"service_account\"");
+
+        // All entries after the block must be preserved
+        assertThat(result).contains("external_apis:");
+        assertThat(result).contains("stripe:");
+        assertThat(result).contains("public_key: pk_test_123");
+        assertThat(result).contains("secret_key: sk_test_456");
+        assertThat(result).contains("twilio:");
+        assertThat(result).contains("account_sid: AC123");
     }
 }

--- a/src/test/java/com/dataliquid/passwordsuite/ui/WorkflowIntegrationIT.java
+++ b/src/test/java/com/dataliquid/passwordsuite/ui/WorkflowIntegrationIT.java
@@ -372,6 +372,101 @@ class WorkflowIntegrationIT extends AbstractSwingIT {
     }
 
     @Nested
+    class EncryptionMenuWorkflows {
+
+        @Test
+        void shouldEncryptMarkedEntriesViaMenu() throws InterruptedException {
+            // 1. Create environment with password
+            window.menuItemWithPath("Settings", "Environments...").click();
+            DialogFixture dialog = window.dialog();
+            dialog.textBox("environmentNameField").enterText("MenuEncryptEnv");
+            dialog.textBox("masterPasswordField").enterText("menupassword12345");
+            dialog.comboBox("algorithmComboBox").selectItem("AES-256-GCM");
+            dialog.button("saveButton").click();
+            dialog.button("okButton").click();
+
+            // 2. Create new file with plain values
+            window.menuItemWithPath("File", "New").click();
+            String yaml = "database:\n  password: secretvalue\n  host: localhost";
+            window.textBox("fileEditor").enterText(yaml);
+            Thread.sleep(800);
+
+            // 3. Expand tree and mark entry for encryption
+            JTreeFixture tree = window.tree("configTree");
+            tree.expandRow(0);
+            tree.expandRow(1);
+            Thread.sleep(200);
+
+            // Mark password entry for encryption via context menu
+            tree.rightClickRow(2);
+            JPopupMenu popup = robot.findActivePopupMenu();
+            new JPopupMenuFixture(robot, popup).menuItemWithPath("Toggle Encryption Marker").click();
+            Thread.sleep(200);
+
+            // 4. Use Edit -> Encryption -> Encrypt Marked menu
+            window.menuItemWithPath("Edit", "Encryption", "Encrypt Marked").click();
+            Thread.sleep(500);
+
+            // 5. VERIFY: Content should be encrypted
+            String encryptedContent = window.textBox("fileEditor").text();
+            assertThat(encryptedContent).contains("ENC[");
+            assertThat(encryptedContent).doesNotContain("secretvalue");
+            assertThat(encryptedContent).contains("host: localhost"); // Unmarked entry unchanged
+        }
+
+        @Test
+        void shouldDecryptMarkedEntriesViaMenu() throws InterruptedException {
+            // 1. Create environment
+            window.menuItemWithPath("Settings", "Environments...").click();
+            DialogFixture dialog = window.dialog();
+            dialog.textBox("environmentNameField").enterText("MenuDecryptEnv");
+            dialog.textBox("masterPasswordField").enterText("menupassword12345");
+            dialog.comboBox("algorithmComboBox").selectItem("AES-256-GCM");
+            dialog.button("saveButton").click();
+            dialog.button("okButton").click();
+
+            // 2. Create file, mark and encrypt first
+            window.menuItemWithPath("File", "New").click();
+            window.textBox("fileEditor").enterText("config:\n  secret: plaintext");
+            Thread.sleep(800);
+
+            JTreeFixture tree = window.tree("configTree");
+            tree.expandRow(0);
+            tree.expandRow(1);
+            Thread.sleep(200);
+
+            // Mark and encrypt via context menu first
+            tree.rightClickRow(2);
+            JPopupMenu popup = robot.findActivePopupMenu();
+            new JPopupMenuFixture(robot, popup).menuItemWithPath("Toggle Encryption Marker").click();
+
+            tree.rightClickRow(2);
+            popup = robot.findActivePopupMenu();
+            new JPopupMenuFixture(robot, popup).menuItemWithPath("Toggle Encrypt/Decrypt").click();
+            Thread.sleep(500);
+
+            // Verify encrypted
+            String encryptedContent = window.textBox("fileEditor").text();
+            assertThat(encryptedContent).contains("ENC[");
+
+            // 3. Mark the encrypted entry for decryption
+            tree.rightClickRow(2);
+            popup = robot.findActivePopupMenu();
+            new JPopupMenuFixture(robot, popup).menuItemWithPath("Toggle Encryption Marker").click();
+            Thread.sleep(200);
+
+            // 4. Use Edit -> Encryption -> Decrypt Marked menu
+            window.menuItemWithPath("Edit", "Encryption", "Decrypt Marked").click();
+            Thread.sleep(500);
+
+            // 5. VERIFY: Content should be decrypted
+            String decryptedContent = window.textBox("fileEditor").text();
+            assertThat(decryptedContent).contains("plaintext");
+            assertThat(decryptedContent).doesNotContain("ENC[");
+        }
+    }
+
+    @Nested
     class EncryptionDecryptionWorkflows {
 
         @Test


### PR DESCRIPTION
## Summary
- Fix EditorService to correctly replace multiline YAML block scalars (`|`, `>`) - entries after the block were being deleted
- Add Edit → Encryption submenu with keyboard shortcuts (Ctrl+Shift+E/D)
- PMD compliance fixes for log statements

## Changes
| File | Description |
|------|-------------|
| `EditorService.java` | New `replaceMultilineValue()` method with `blockEnded` flag to preserve subsequent entries |
| `MainFrame.java` | Encryption submenu with Encrypt/Decrypt Marked menu items |
| `EnvironmentsHandler.java` | PMD-compliant log statements |
| `EditorServiceTest.java` | 3 new unit tests for multiline YAML handling |
| `WorkflowIntegrationIT.java` | 2 new UI tests for Encryption menu |

## Test plan
- [ ] Run `mvn clean test` - all 138 unit tests pass
- [ ] Run `mvn verify` - UI integration tests pass
- [ ] Manual test: Load YAML with multiline block scalar (`|`), encrypt it, verify subsequent entries are preserved
- [ ] Manual test: Use Edit → Encryption → Encrypt Marked (Ctrl+Shift+E) and Decrypt Marked (Ctrl+Shift+D)