### PR TITLE
Add tree inline value editing with Insert key

### DIFF
--- a/src/main/java/com/dataliquid/passwordsuite/ui/MainFrame.java
+++ b/src/main/java/com/dataliquid/passwordsuite/ui/MainFrame.java
@@ -18,6 +18,7 @@ import javax.swing.JOptionPane;
 import javax.swing.JPanel;
 import javax.swing.JSplitPane;
 import javax.swing.KeyStroke;
+import javax.swing.SwingUtilities;
 import javax.swing.tree.DefaultMutableTreeNode;
 import javax.swing.tree.TreePath;
 
@@ -160,6 +161,18 @@ public final class MainFrame extends JFrame {
                 .setCryptoToggleCallback(entry -> cryptoHandler
                         .handleTreeDoubleClick(entry, tabbedEditorPanel.getActiveTab(), treePanel::refresh,
                                 this::showError));
+
+        // Tree inline value edit callback - for Insert key editing
+        treePanel.setValueEditCallback((entry, newValue) -> {
+            FileTab activeTab = tabbedEditorPanel.getActiveTab();
+            if (activeTab != null) {
+                String oldValue = entry.getValue();
+                entry.setValue(newValue);
+                editorService.replaceValueInEditor(entry, oldValue, newValue, activeTab.getEditor());
+                // Defer refresh to avoid recursion during cell editor completion
+                SwingUtilities.invokeLater(treePanel::refresh);
+            }
+        });
 
         // Tree double-click listener - toggle encrypt/decrypt
         treePanel.tree.addMouseListener(new MouseAdapter() {

--- a/src/main/java/com/dataliquid/passwordsuite/ui/TreePanel.java
+++ b/src/main/java/com/dataliquid/passwordsuite/ui/TreePanel.java
@@ -5,20 +5,25 @@ import java.awt.Component;
 import java.awt.Toolkit;
 import java.awt.datatransfer.StringSelection;
 import java.awt.event.InputEvent;
+import java.awt.event.KeyAdapter;
 import java.awt.event.KeyEvent;
 import java.awt.event.MouseAdapter;
 import java.awt.event.MouseEvent;
 import java.util.ArrayList;
+import java.util.EventObject;
 import java.util.List;
+import java.util.function.BiConsumer;
 import java.util.function.Consumer;
 import java.util.function.Supplier;
 import java.util.stream.Collectors;
 
 import javax.swing.BorderFactory;
+import javax.swing.DefaultCellEditor;
 import javax.swing.JMenuItem;
 import javax.swing.JPanel;
 import javax.swing.JPopupMenu;
 import javax.swing.JScrollPane;
+import javax.swing.JTextField;
 import javax.swing.JTree;
 import javax.swing.KeyStroke;
 import javax.swing.tree.DefaultMutableTreeNode;
@@ -46,6 +51,7 @@ public final class TreePanel extends JPanel {
     private Consumer<Void> markerChangeCallback;
     private Consumer<ConfigEntry> cryptoToggleCallback;
     private Supplier<Boolean> isYamlFormatSupplier;
+    private BiConsumer<ConfigEntry, String> valueEditCallback;
 
     public TreePanel() {
         setLayout(new BorderLayout());
@@ -62,6 +68,18 @@ public final class TreePanel extends JPanel {
 
         // Enable multi-selection (CTRL+click, SHIFT+click)
         tree.getSelectionModel().setSelectionMode(TreeSelectionModel.DISCONTIGUOUS_TREE_SELECTION);
+
+        // Setup inline editing with Insert key
+        tree.setEditable(true);
+        tree.setCellEditor(new ConfigEntryCellEditor());
+        tree.addKeyListener(new KeyAdapter() {
+            @Override
+            public void keyPressed(KeyEvent e) {
+                if (e.getKeyCode() == KeyEvent.VK_INSERT) {
+                    startEditingSelectedEntry();
+                }
+            }
+        });
 
         // Context menu for marking/unmarking entries
         setupContextMenu();
@@ -90,6 +108,28 @@ public final class TreePanel extends JPanel {
      */
     public void setFormatSupplier(Supplier<Boolean> supplier) {
         this.isYamlFormatSupplier = supplier;
+    }
+
+    /**
+     * Sets the callback to be invoked when a value is edited inline.
+     *
+     * @param callback receives the ConfigEntry and the new value
+     */
+    public void setValueEditCallback(BiConsumer<ConfigEntry, String> callback) {
+        this.valueEditCallback = callback;
+    }
+
+    /**
+     * Starts inline editing for the currently selected entry.
+     */
+    private void startEditingSelectedEntry() {
+        TreePath path = tree.getSelectionPath();
+        if (path != null) {
+            DefaultMutableTreeNode node = (DefaultMutableTreeNode) path.getLastPathComponent();
+            if (node.getUserObject() instanceof ConfigEntry) {
+                tree.startEditingAtPath(path);
+            }
+        }
     }
 
     /**
@@ -347,6 +387,85 @@ public final class TreePanel extends JPanel {
                 return base + " [ENC]";
             }
             return base;
+        }
+    }
+
+    /**
+     * Custom TreeCellEditor that allows editing only the value of ConfigEntry
+     * nodes. Editing is triggered by the Insert key and only works on ConfigEntry
+     * nodes.
+     */
+    @SuppressWarnings("PMD.NullAssignment")
+    private final class ConfigEntryCellEditor extends DefaultCellEditor {
+        private static final long serialVersionUID = 1L;
+        private transient ConfigEntry currentEntry;
+        private String originalValue;
+        private boolean cancelled;
+
+        ConfigEntryCellEditor() {
+            super(new JTextField());
+            // Add key listener to catch Escape before DefaultCellEditor processes it
+            JTextField textField = (JTextField) getComponent();
+            textField.addKeyListener(new java.awt.event.KeyAdapter() {
+                @Override
+                public void keyPressed(java.awt.event.KeyEvent e) {
+                    if (e.getKeyCode() == java.awt.event.KeyEvent.VK_ESCAPE) {
+                        cancelled = true;
+                    }
+                }
+            });
+        }
+
+        @Override
+        public boolean isCellEditable(EventObject event) {
+            return event == null;
+        }
+
+        @Override
+        public Component getTreeCellEditorComponent(JTree editTree, Object value, boolean isSelected, boolean expanded,
+                boolean leaf, int row) {
+            cancelled = false;
+            if (value instanceof DefaultMutableTreeNode) {
+                DefaultMutableTreeNode node = (DefaultMutableTreeNode) value;
+                Object userObject = node.getUserObject();
+
+                if (userObject instanceof ConfigEntry) {
+                    currentEntry = (ConfigEntry) userObject;
+                    originalValue = currentEntry.getValue();
+                    JTextField textField = (JTextField) getComponent();
+                    textField.setText(originalValue);
+                    return textField;
+                }
+            }
+            currentEntry = null;
+            originalValue = null;
+            return super.getTreeCellEditorComponent(editTree, value, isSelected, expanded, leaf, row);
+        }
+
+        @Override
+        public void cancelCellEditing() {
+            cancelled = true;
+            super.cancelCellEditing();
+        }
+
+        @Override
+        public boolean stopCellEditing() {
+            if (!cancelled) {
+                JTextField textField = (JTextField) getComponent();
+                String newValue = textField.getText();
+
+                if (currentEntry != null && valueEditCallback != null && !newValue.equals(originalValue)) {
+                    valueEditCallback.accept(currentEntry, newValue);
+                }
+            }
+
+            return super.stopCellEditing();
+        }
+
+        @Override
+        public Object getCellEditorValue() {
+            JTextField textField = (JTextField) getComponent();
+            return cancelled ? originalValue : textField.getText();
         }
     }
 

--- a/src/main/java/com/dataliquid/passwordsuite/ui/handler/EnvironmentsHandler.java
+++ b/src/main/java/com/dataliquid/passwordsuite/ui/handler/EnvironmentsHandler.java
@@ -147,7 +147,6 @@ public class EnvironmentsHandler {
     /**
      * Handles algorithm selection change.
      */
-    @SuppressWarnings("PMD.InvalidLogMessageFormat")
     public void handleAlgorithmChange() {
         FileTab activeTab = tabbedEditorPanel.getActiveTab();
         if (activeTab != null) {
@@ -170,7 +169,7 @@ public class EnvironmentsHandler {
                 }
             } catch (CryptoException e) {
                 if (logger.isErrorEnabled()) {
-                    logger.error("Failed to switch algorithm to: {} - {}", selected, e.getMessage(), e);
+                    logger.error("Failed to switch algorithm to: " + selected, e);
                 }
                 JOptionPane
                         .showMessageDialog(parentFrame, "Failed to switch algorithm: " + e.getMessage(),
@@ -182,7 +181,6 @@ public class EnvironmentsHandler {
     /**
      * Handles environment selection change.
      */
-    @SuppressWarnings("PMD.InvalidLogMessageFormat")
     public void handleEnvironmentChange() {
         String selected = actionPanel.getSelectedEnvironment();
         logger.debug("Environment change requested: {}", selected);
@@ -196,9 +194,7 @@ public class EnvironmentsHandler {
                 updateCryptoServicePassword();
             } catch (CryptoException e) {
                 if (logger.isErrorEnabled()) {
-                    logger
-                            .error("Failed to update CryptoService for environment: {} - {}", selected, e.getMessage(),
-                                    e);
+                    logger.error("Failed to update CryptoService for environment: " + selected, e);
                 }
             }
         }
@@ -211,7 +207,7 @@ public class EnvironmentsHandler {
                 cryptoService.setAlgorithm(defaultAlgorithm);
             } catch (CryptoException e) {
                 if (logger.isErrorEnabled()) {
-                    logger.error("Failed to set default algorithm: {} - {}", defaultAlgorithm, e.getMessage(), e);
+                    logger.error("Failed to set default algorithm: " + defaultAlgorithm, e);
                 }
             }
         } else {

--- a/src/test/java/com/dataliquid/passwordsuite/ui/TreePanelIT.java
+++ b/src/test/java/com/dataliquid/passwordsuite/ui/TreePanelIT.java
@@ -11,6 +11,7 @@ import org.assertj.swing.edt.GuiActionRunner;
 import org.assertj.swing.fixture.DialogFixture;
 import org.assertj.swing.fixture.FrameFixture;
 import org.assertj.swing.fixture.JPopupMenuFixture;
+import org.assertj.swing.fixture.JTextComponentFixture;
 import org.assertj.swing.fixture.JTreeFixture;
 import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.BeforeEach;
@@ -788,6 +789,146 @@ class TreePanelIT extends AbstractSwingIT {
             assertThat(clipboardContent).contains("=");
             assertThat(clipboardContent).contains("host");
             assertThat(clipboardContent).contains("localhost");
+        }
+    }
+
+    @Nested
+    class InlineEditing {
+
+        @Test
+        void shouldStartEditingOnInsertKey() throws InterruptedException {
+            // 1. Content erstellen
+            window.menuItemWithPath("File", "New").click();
+            window.textBox("fileEditor").enterText(SAMPLE_YAML);
+            Thread.sleep(800);
+
+            // 2. Tree expandieren und Entry selektieren
+            JTreeFixture tree = window.tree("configTree");
+            tree.expandRow(0);
+            tree.expandRow(1);
+            Thread.sleep(200);
+            tree.clickRow(2); // host entry
+
+            // 3. Insert-Taste druecken
+            robot.pressKey(java.awt.event.KeyEvent.VK_INSERT);
+            robot.releaseKey(java.awt.event.KeyEvent.VK_INSERT);
+            robot.waitForIdle();
+            Thread.sleep(200);
+
+            // 4. Pruefen ob Editing aktiv ist
+            boolean isEditing = GuiActionRunner.execute(() -> tree.target().isEditing());
+            assertThat(isEditing).as("Tree should be in editing mode after Insert key").isTrue();
+        }
+
+        @Test
+        void shouldUpdateValueOnEnter() throws InterruptedException {
+            // 1. Content erstellen
+            window.menuItemWithPath("File", "New").click();
+            window.textBox("fileEditor").enterText(SAMPLE_YAML);
+            Thread.sleep(800);
+
+            // 2. Tree expandieren und Entry selektieren
+            JTreeFixture tree = window.tree("configTree");
+            tree.expandRow(0);
+            tree.expandRow(1);
+            Thread.sleep(200);
+            tree.clickRow(2); // host entry
+
+            // 3. Insert-Taste druecken zum Start des Editings
+            robot.pressKey(java.awt.event.KeyEvent.VK_INSERT);
+            robot.releaseKey(java.awt.event.KeyEvent.VK_INSERT);
+            robot.waitForIdle();
+            Thread.sleep(200);
+
+            // 4. Neuen Wert eingeben
+            robot.enterText("newhost");
+            Thread.sleep(100);
+
+            // 5. Enter druecken zum Bestaetigen
+            robot.pressKey(java.awt.event.KeyEvent.VK_ENTER);
+            robot.releaseKey(java.awt.event.KeyEvent.VK_ENTER);
+            robot.waitForIdle();
+            Thread.sleep(300);
+
+            // 6. Pruefen ob Editor-Text aktualisiert wurde
+            String editorContent = window.textBox("fileEditor").text();
+            assertThat(editorContent).contains("newhost");
+            assertThat(editorContent).doesNotContain("localhost");
+        }
+
+        @Test
+        void shouldCancelEditingOnEscape() throws InterruptedException {
+            // 1. Content erstellen
+            window.menuItemWithPath("File", "New").click();
+            window.textBox("fileEditor").enterText(SAMPLE_YAML);
+            Thread.sleep(800);
+
+            // 2. Tree expandieren und Entry selektieren
+            JTreeFixture tree = window.tree("configTree");
+            tree.expandRow(0);
+            tree.expandRow(1);
+            Thread.sleep(200);
+            tree.clickRow(2); // host entry
+
+            // 3. Insert-Taste druecken zum Start des Editings
+            robot.pressKey(java.awt.event.KeyEvent.VK_INSERT);
+            robot.releaseKey(java.awt.event.KeyEvent.VK_INSERT);
+            robot.waitForIdle();
+            Thread.sleep(300);
+
+            // 4. Verify editing is active
+            boolean isEditing = GuiActionRunner.execute(() -> tree.target().isEditing());
+            assertThat(isEditing).as("Tree should be in editing mode").isTrue();
+
+            // 5. Focus on the cell editor textfield and type
+            javax.swing.JTextField cellEditorField = GuiActionRunner.execute(() -> {
+                javax.swing.CellEditor cellEditor = tree.target().getCellEditor();
+                if (cellEditor instanceof javax.swing.DefaultCellEditor) {
+                    return (javax.swing.JTextField) ((javax.swing.DefaultCellEditor) cellEditor).getComponent();
+                }
+                return null;
+            });
+            assertThat(cellEditorField).isNotNull();
+
+            // 5. Press Escape to cancel without any text changes
+            robot.pressKey(java.awt.event.KeyEvent.VK_ESCAPE);
+            robot.releaseKey(java.awt.event.KeyEvent.VK_ESCAPE);
+            robot.waitForIdle();
+            Thread.sleep(300);
+
+            // 6. Verify editing was cancelled
+            boolean isEditingAfter = GuiActionRunner.execute(() -> tree.target().isEditing());
+            assertThat(isEditingAfter).as("Tree should not be in editing mode after Escape").isFalse();
+
+            // 7. Verify editor unchanged
+            String editorContent = window.textBox("fileEditor").text();
+            assertThat(editorContent).contains("localhost");
+        }
+
+        @Test
+        void shouldNotEditGroupNodes() throws InterruptedException {
+            // 1. Content erstellen
+            window.menuItemWithPath("File", "New").click();
+            window.textBox("fileEditor").enterText(SAMPLE_YAML);
+            Thread.sleep(800);
+
+            // 2. Tree expandieren
+            JTreeFixture tree = window.tree("configTree");
+            tree.expandRow(0);
+            Thread.sleep(200);
+
+            // 3. Group-Node selektieren (database)
+            tree.clickRow(1);
+
+            // 4. Insert-Taste druecken
+            robot.pressKey(java.awt.event.KeyEvent.VK_INSERT);
+            robot.releaseKey(java.awt.event.KeyEvent.VK_INSERT);
+            robot.waitForIdle();
+            Thread.sleep(200);
+
+            // 5. Pruefen dass KEIN Editing aktiv ist
+            boolean isEditing = GuiActionRunner.execute(() -> tree.target().isEditing());
+            assertThat(isEditing).as("Group nodes should not be editable").isFalse();
         }
     }
 }


### PR DESCRIPTION
## Summary
- Add inline value editing in tree panel using Insert key to start editing
- Fix StackOverflow recursion by deferring tree refresh with SwingUtilities.invokeLater()
- Properly handle Escape key cancellation in cell editor with cancelled flag

## Test plan
- [x] Verify Insert key starts editing on ConfigEntry nodes
- [x] Verify Enter key confirms edit and updates editor content
- [x] Verify Escape key cancels edit without modifying content
- [x] Verify no StackOverflow when editing values
- [x] Run all integration tests with `mvn verify`