### PR TITLE
#7 Add drag and drop support for files

### DIFF
--- a/src/main/java/com/dataliquid/passwordsuite/ui/MainFrame.java
+++ b/src/main/java/com/dataliquid/passwordsuite/ui/MainFrame.java
@@ -35,6 +35,7 @@ import com.dataliquid.passwordsuite.service.FileIOService;
 import com.dataliquid.passwordsuite.ui.handler.CryptoOperationHandler;
 import com.dataliquid.passwordsuite.ui.handler.EditOperationHandler;
 import com.dataliquid.passwordsuite.ui.handler.EnvironmentsHandler;
+import com.dataliquid.passwordsuite.ui.handler.FileDropHandler;
 import com.dataliquid.passwordsuite.ui.handler.FileOperationHandler;
 import com.dataliquid.passwordsuite.ui.handler.PasswordManager;
 
@@ -116,6 +117,9 @@ public final class MainFrame extends JFrame {
 
         // Menu bar
         setupMenuBar();
+
+        // Drag and drop support
+        setupDragAndDrop();
 
         logger.info("MainFrame initialized successfully");
     }
@@ -227,6 +231,23 @@ public final class MainFrame extends JFrame {
         menuBar.add(editMenu);
         menuBar.add(settingsMenu);
         setJMenuBar(menuBar);
+    }
+
+    private void setupDragAndDrop() {
+        FileDropHandler dropHandler = new FileDropHandler(file -> {
+            try {
+                fileHandler.openFile(file);
+            } catch (java.io.IOException e) {
+                if (logger.isErrorEnabled()) {
+                    logger.error("Failed to open dropped file: {}", file.getName(), e);
+                }
+                showError("Failed to open file: " + file.getName());
+            }
+        });
+        ((JComponent) getContentPane()).setTransferHandler(dropHandler);
+        if (logger.isDebugEnabled()) {
+            logger.debug("Drag and drop support enabled");
+        }
     }
 
     private JMenuItem createMenuItem(String text, char mnemonic, java.awt.event.ActionListener listener) {

--- a/src/main/java/com/dataliquid/passwordsuite/ui/handler/EnvironmentsHandler.java
+++ b/src/main/java/com/dataliquid/passwordsuite/ui/handler/EnvironmentsHandler.java
@@ -147,7 +147,6 @@ public class EnvironmentsHandler {
     /**
      * Handles algorithm selection change.
      */
-    @SuppressWarnings("PMD.InvalidLogMessageFormat")
     public void handleAlgorithmChange() {
         FileTab activeTab = tabbedEditorPanel.getActiveTab();
         if (activeTab != null) {
@@ -170,7 +169,7 @@ public class EnvironmentsHandler {
                 }
             } catch (CryptoException e) {
                 if (logger.isErrorEnabled()) {
-                    logger.error("Failed to switch algorithm to: {} - {}", selected, e.getMessage(), e);
+                    logger.error("Failed to switch algorithm to: " + selected, e);
                 }
                 JOptionPane
                         .showMessageDialog(parentFrame, "Failed to switch algorithm: " + e.getMessage(),
@@ -182,7 +181,6 @@ public class EnvironmentsHandler {
     /**
      * Handles environment selection change.
      */
-    @SuppressWarnings("PMD.InvalidLogMessageFormat")
     public void handleEnvironmentChange() {
         String selected = actionPanel.getSelectedEnvironment();
         logger.debug("Environment change requested: {}", selected);
@@ -196,9 +194,7 @@ public class EnvironmentsHandler {
                 updateCryptoServicePassword();
             } catch (CryptoException e) {
                 if (logger.isErrorEnabled()) {
-                    logger
-                            .error("Failed to update CryptoService for environment: {} - {}", selected, e.getMessage(),
-                                    e);
+                    logger.error("Failed to update CryptoService for environment: " + selected, e);
                 }
             }
         }
@@ -211,7 +207,7 @@ public class EnvironmentsHandler {
                 cryptoService.setAlgorithm(defaultAlgorithm);
             } catch (CryptoException e) {
                 if (logger.isErrorEnabled()) {
-                    logger.error("Failed to set default algorithm: {} - {}", defaultAlgorithm, e.getMessage(), e);
+                    logger.error("Failed to set default algorithm: " + defaultAlgorithm, e);
                 }
             }
         } else {

--- a/src/main/java/com/dataliquid/passwordsuite/ui/handler/FileDropHandler.java
+++ b/src/main/java/com/dataliquid/passwordsuite/ui/handler/FileDropHandler.java
@@ -1,0 +1,129 @@
+package com.dataliquid.passwordsuite.ui.handler;
+
+import java.awt.datatransfer.DataFlavor;
+import java.awt.datatransfer.Transferable;
+import java.awt.datatransfer.UnsupportedFlavorException;
+import java.io.File;
+import java.io.IOException;
+import java.util.ArrayList;
+import java.util.List;
+import java.util.Locale;
+import java.util.Set;
+import java.util.function.Consumer;
+
+import javax.swing.TransferHandler;
+
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+/**
+ * Handles drag and drop of files into the application.
+ * <p>
+ * Accepts files with extensions: .properties, .yaml, .yml
+ * </p>
+ */
+public class FileDropHandler extends TransferHandler {
+
+    private static final long serialVersionUID = 1L;
+    private static final Logger logger = LoggerFactory.getLogger(FileDropHandler.class);
+
+    private static final Set<String> VALID_EXTENSIONS = Set.of("properties", "yaml", "yml");
+
+    private final transient Consumer<File> fileOpenCallback;
+
+    /**
+     * Creates a new FileDropHandler.
+     *
+     * @param fileOpenCallback callback invoked for each valid dropped file
+     */
+    public FileDropHandler(Consumer<File> fileOpenCallback) {
+        this.fileOpenCallback = fileOpenCallback;
+    }
+
+    @Override
+    public boolean canImport(TransferSupport support) {
+        return support.isDataFlavorSupported(DataFlavor.javaFileListFlavor);
+    }
+
+    @Override
+    public boolean importData(TransferSupport support) {
+        if (!canImport(support)) {
+            return false;
+        }
+
+        Transferable transferable = support.getTransferable();
+        List<File> validFiles = extractValidFiles(transferable);
+
+        if (validFiles.isEmpty()) {
+            if (logger.isDebugEnabled()) {
+                logger.debug("No valid files in drop");
+            }
+            return false;
+        }
+
+        for (File file : validFiles) {
+            try {
+                fileOpenCallback.accept(file);
+            } catch (Exception e) {
+                if (logger.isErrorEnabled()) {
+                    logger.error("Failed to open dropped file: {}", file.getName(), e);
+                }
+            }
+        }
+
+        if (logger.isInfoEnabled()) {
+            logger.info("Dropped {} file(s)", validFiles.size());
+        }
+        return true;
+    }
+
+    /**
+     * Extracts valid files from the transferable.
+     * <p>
+     * Filters for files with valid extensions (.properties, .yaml, .yml).
+     * </p>
+     *
+     * @param  transferable the transferable containing dropped data
+     *
+     * @return              list of valid files, empty if none found
+     */
+    @SuppressWarnings("unchecked")
+    List<File> extractValidFiles(Transferable transferable) {
+        List<File> validFiles = new ArrayList<>();
+
+        try {
+            List<File> droppedFiles = (List<File>) transferable.getTransferData(DataFlavor.javaFileListFlavor);
+
+            for (File file : droppedFiles) {
+                if (file.isFile() && hasValidExtension(file)) {
+                    validFiles.add(file);
+                } else if (logger.isDebugEnabled()) {
+                    logger.debug("Skipping invalid file: {}", file.getName());
+                }
+            }
+        } catch (UnsupportedFlavorException | IOException e) {
+            if (logger.isErrorEnabled()) {
+                logger.error("Failed to extract files from drop", e);
+            }
+        }
+
+        return validFiles;
+    }
+
+    /**
+     * Checks if the file has a valid extension.
+     *
+     * @param  file the file to check
+     *
+     * @return      true if the file has a valid extension
+     */
+    boolean hasValidExtension(File file) {
+        String name = file.getName().toLowerCase(Locale.ROOT);
+        int lastDot = name.lastIndexOf('.');
+        if (lastDot == -1) {
+            return false;
+        }
+        String extension = name.substring(lastDot + 1);
+        return VALID_EXTENSIONS.contains(extension);
+    }
+}

--- a/src/test/java/com/dataliquid/passwordsuite/ui/FileDropIT.java
+++ b/src/test/java/com/dataliquid/passwordsuite/ui/FileDropIT.java
@@ -1,0 +1,199 @@
+package com.dataliquid.passwordsuite.ui;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import java.awt.datatransfer.DataFlavor;
+import java.awt.datatransfer.Transferable;
+import java.awt.datatransfer.UnsupportedFlavorException;
+import java.io.File;
+import java.io.IOException;
+import java.nio.file.Files;
+import java.util.Arrays;
+import java.util.List;
+
+import javax.swing.JComponent;
+import javax.swing.TransferHandler;
+import javax.swing.TransferHandler.TransferSupport;
+
+import org.assertj.swing.edt.GuiActionRunner;
+import org.assertj.swing.fixture.FrameFixture;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.io.TempDir;
+
+/**
+ * Integration tests for drag and drop file support.
+ */
+@DisplayName("File Drag & Drop Integration Tests")
+class FileDropIT extends AbstractSwingIT {
+
+    private FrameFixture window;
+    private MainFrame frame;
+
+    @TempDir
+    File tempDir;
+
+    @BeforeEach
+    void setUpFrame() {
+        frame = GuiActionRunner.execute(() -> new MainFrame());
+        window = new FrameFixture(robot, frame);
+        window.show(new java.awt.Dimension(1400, 900));
+    }
+
+    @AfterEach
+    void tearDownFrame() {
+        if (window != null) {
+            window.cleanUp();
+        }
+    }
+
+    @Test
+    @DisplayName("should open single file via drag and drop")
+    void shouldOpenSingleFileViaDragAndDrop() throws IOException {
+        // Given: A properties file
+        File propertiesFile = createTempFile("config.properties", "server.port=8080\nserver.host=localhost");
+
+        // When: Drop the file
+        simulateFileDrop(Arrays.asList(propertiesFile));
+
+        // Then: A new tab is created with the file content
+        assertThat(frame.getTabbedEditorPanel().getTabCount()).isEqualTo(1); // dropped file creates tab
+        FileTab activeTab = frame.getTabbedEditorPanel().getActiveTab();
+        assertThat(activeTab).isNotNull();
+        assertThat(activeTab.getFile()).isEqualTo(propertiesFile);
+        assertThat(activeTab.getText()).contains("server.port=8080");
+    }
+
+    @Test
+    @DisplayName("should open multiple files via drag and drop")
+    void shouldOpenMultipleFilesViaDragAndDrop() throws IOException {
+        // Given: Multiple valid files
+        File file1 = createTempFile("config.properties", "key1=value1");
+        File file2 = createTempFile("settings.yaml", "key2: value2");
+        File file3 = createTempFile("data.yml", "key3: value3");
+
+        // When: Drop all files
+        simulateFileDrop(Arrays.asList(file1, file2, file3));
+
+        // Then: 3 new tabs are created
+        assertThat(frame.getTabbedEditorPanel().getTabCount()).isEqualTo(3);
+    }
+
+    @Test
+    @DisplayName("should ignore files with invalid extension")
+    void shouldIgnoreFilesWithInvalidExtension() throws IOException {
+        // Given: One valid and one invalid file
+        File validFile = createTempFile("config.properties", "valid=true");
+        File invalidFile = createTempFile("readme.txt", "This is a text file");
+
+        // When: Drop both files
+        simulateFileDrop(Arrays.asList(validFile, invalidFile));
+
+        // Then: Only the valid file creates a tab
+        assertThat(frame.getTabbedEditorPanel().getTabCount()).isEqualTo(1); // only valid file
+        FileTab activeTab = frame.getTabbedEditorPanel().getActiveTab();
+        assertThat(activeTab.getFile()).isEqualTo(validFile);
+    }
+
+    @Test
+    @DisplayName("should handle mixed valid and invalid files")
+    void shouldHandleMixedValidAndInvalidFiles() throws IOException {
+        // Given: A mix of valid and invalid files
+        File propFile = createTempFile("test.properties", "prop=value");
+        File txtFile = createTempFile("readme.txt", "text content");
+        File yamlFile = createTempFile("config.yaml", "yaml: content");
+        File pngFile = createTempFile("image.png", "fake png content");
+
+        // When: Drop all files
+        simulateFileDrop(Arrays.asList(propFile, txtFile, yamlFile, pngFile));
+
+        // Then: Only 2 valid files create tabs
+        assertThat(frame.getTabbedEditorPanel().getTabCount()).isEqualTo(2); // only valid files
+    }
+
+    @Test
+    @DisplayName("should parse dropped file content automatically")
+    void shouldParseDroppedFileContentAutomatically() throws IOException {
+        // Given: A properties file with configuration entries
+        File propertiesFile = createTempFile("app.properties",
+                "database.url=jdbc:mysql://localhost:3306/mydb\ndatabase.user=admin\ndatabase.password=secret");
+
+        // When: Drop the file
+        simulateFileDrop(Arrays.asList(propertiesFile));
+
+        // Then: The file is parsed and tree is populated
+        // Wait for EDT to process
+        GuiActionRunner.execute(() -> {
+            FileTab activeTab = frame.getTabbedEditorPanel().getActiveTab();
+            // ConfigTree should be set after auto-parse
+            assertThat(activeTab.getConfigTree()).isNotNull();
+            assertThat(activeTab.getConfigTree().getEntryCount()).isEqualTo(3);
+        });
+    }
+
+    @Test
+    @DisplayName("should accept yaml files via drag and drop")
+    void shouldAcceptYamlFilesViaDragAndDrop() throws IOException {
+        // Given: A YAML file
+        File yamlFile = createTempFile("config.yaml", "server:\n  port: 8080\n  host: localhost");
+
+        // When: Drop the file
+        simulateFileDrop(Arrays.asList(yamlFile));
+
+        // Then: Tab is created with YAML content
+        assertThat(frame.getTabbedEditorPanel().getTabCount()).isEqualTo(1);
+        FileTab activeTab = frame.getTabbedEditorPanel().getActiveTab();
+        assertThat(activeTab.getFile().getName()).endsWith(".yaml");
+        assertThat(activeTab.getText()).contains("server:");
+    }
+
+    @Test
+    @DisplayName("should have transfer handler on content pane")
+    void shouldHaveTransferHandlerOnContentPane() {
+        // The content pane should have a TransferHandler configured
+        TransferHandler handler = GuiActionRunner
+                .execute(() -> ((JComponent) frame.getContentPane()).getTransferHandler());
+        assertThat(handler).isNotNull();
+    }
+
+    private File createTempFile(String name, String content) throws IOException {
+        File file = new File(tempDir, name);
+        Files.writeString(file.toPath(), content);
+        return file;
+    }
+
+    private void simulateFileDrop(List<File> files) {
+        GuiActionRunner.execute(() -> {
+            JComponent contentPane = (JComponent) frame.getContentPane();
+            TransferHandler handler = contentPane.getTransferHandler();
+            Transferable transferable = createFileTransferable(files);
+            TransferSupport support = new TransferSupport(contentPane, transferable);
+            handler.importData(support);
+            return null;
+        });
+    }
+
+    private Transferable createFileTransferable(List<File> files) {
+        return new Transferable() {
+            @Override
+            public DataFlavor[] getTransferDataFlavors() {
+                return new DataFlavor[] { DataFlavor.javaFileListFlavor };
+            }
+
+            @Override
+            public boolean isDataFlavorSupported(DataFlavor flavor) {
+                return DataFlavor.javaFileListFlavor.equals(flavor);
+            }
+
+            @Override
+            public Object getTransferData(DataFlavor flavor) throws UnsupportedFlavorException {
+                if (!isDataFlavorSupported(flavor)) {
+                    throw new UnsupportedFlavorException(flavor);
+                }
+                return files;
+            }
+        };
+    }
+}

--- a/src/test/java/com/dataliquid/passwordsuite/ui/handler/FileDropHandlerTest.java
+++ b/src/test/java/com/dataliquid/passwordsuite/ui/handler/FileDropHandlerTest.java
@@ -1,0 +1,253 @@
+package com.dataliquid.passwordsuite.ui.handler;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+import java.awt.datatransfer.DataFlavor;
+import java.awt.datatransfer.StringSelection;
+import java.awt.datatransfer.Transferable;
+import java.awt.datatransfer.UnsupportedFlavorException;
+import java.io.File;
+import java.io.IOException;
+import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.List;
+
+import javax.swing.JPanel;
+import javax.swing.TransferHandler.TransferSupport;
+
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Nested;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.io.TempDir;
+
+@DisplayName("FileDropHandler")
+class FileDropHandlerTest {
+
+    private List<File> openedFiles;
+    private FileDropHandler handler;
+
+    @TempDir
+    File tempDir;
+
+    @BeforeEach
+    void setUp() {
+        openedFiles = new ArrayList<>();
+        handler = new FileDropHandler(openedFiles::add);
+    }
+
+    @Nested
+    @DisplayName("canImport")
+    class CanImport {
+
+        @Test
+        @DisplayName("should return true for javaFileListFlavor")
+        void shouldReturnTrueForFileListFlavor() {
+            Transferable transferable = createFileTransferable(Arrays.asList(new File("test.properties")));
+            TransferSupport support = new TransferSupport(new JPanel(), transferable);
+
+            assertTrue(handler.canImport(support));
+        }
+
+        @Test
+        @DisplayName("should return false for string flavor")
+        void shouldReturnFalseForStringFlavor() {
+            Transferable transferable = new StringSelection("just a string");
+            TransferSupport support = new TransferSupport(new JPanel(), transferable);
+
+            assertFalse(handler.canImport(support));
+        }
+    }
+
+    @Nested
+    @DisplayName("hasValidExtension")
+    class HasValidExtension {
+
+        @Test
+        @DisplayName("should accept .properties files")
+        void shouldAcceptPropertiesFiles() {
+            assertTrue(handler.hasValidExtension(new File("config.properties")));
+        }
+
+        @Test
+        @DisplayName("should accept .yaml files")
+        void shouldAcceptYamlFiles() {
+            assertTrue(handler.hasValidExtension(new File("config.yaml")));
+        }
+
+        @Test
+        @DisplayName("should accept .yml files")
+        void shouldAcceptYmlFiles() {
+            assertTrue(handler.hasValidExtension(new File("config.yml")));
+        }
+
+        @Test
+        @DisplayName("should accept uppercase extensions")
+        void shouldAcceptUppercaseExtensions() {
+            assertTrue(handler.hasValidExtension(new File("CONFIG.PROPERTIES")));
+            assertTrue(handler.hasValidExtension(new File("CONFIG.YAML")));
+            assertTrue(handler.hasValidExtension(new File("CONFIG.YML")));
+        }
+
+        @Test
+        @DisplayName("should reject .txt files")
+        void shouldRejectTxtFiles() {
+            assertFalse(handler.hasValidExtension(new File("readme.txt")));
+        }
+
+        @Test
+        @DisplayName("should reject files without extension")
+        void shouldRejectFilesWithoutExtension() {
+            assertFalse(handler.hasValidExtension(new File("Makefile")));
+        }
+
+        @Test
+        @DisplayName("should reject .json files")
+        void shouldRejectJsonFiles() {
+            assertFalse(handler.hasValidExtension(new File("config.json")));
+        }
+    }
+
+    @Nested
+    @DisplayName("extractValidFiles")
+    class ExtractValidFiles {
+
+        @Test
+        @DisplayName("should extract valid files from transferable")
+        void shouldExtractValidFiles() throws IOException {
+            File validFile = createTempFile("config.properties");
+            Transferable transferable = createFileTransferable(Arrays.asList(validFile));
+
+            List<File> result = handler.extractValidFiles(transferable);
+
+            assertEquals(1, result.size());
+            assertEquals(validFile, result.get(0));
+        }
+
+        @Test
+        @DisplayName("should filter out invalid extensions")
+        void shouldFilterOutInvalidExtensions() throws IOException {
+            File validFile = createTempFile("config.properties");
+            File invalidFile = createTempFile("readme.txt");
+            Transferable transferable = createFileTransferable(Arrays.asList(validFile, invalidFile));
+
+            List<File> result = handler.extractValidFiles(transferable);
+
+            assertEquals(1, result.size());
+            assertEquals(validFile, result.get(0));
+        }
+
+        @Test
+        @DisplayName("should filter out directories")
+        void shouldFilterOutDirectories() throws IOException {
+            File validFile = createTempFile("config.properties");
+            File directory = new File(tempDir, "subdir");
+            directory.mkdir();
+            Transferable transferable = createFileTransferable(Arrays.asList(validFile, directory));
+
+            List<File> result = handler.extractValidFiles(transferable);
+
+            assertEquals(1, result.size());
+            assertEquals(validFile, result.get(0));
+        }
+
+        @Test
+        @DisplayName("should return empty list for invalid transferable")
+        void shouldReturnEmptyListForInvalidTransferable() {
+            Transferable transferable = new StringSelection("not a file list");
+
+            List<File> result = handler.extractValidFiles(transferable);
+
+            assertTrue(result.isEmpty());
+        }
+    }
+
+    @Nested
+    @DisplayName("importData")
+    class ImportData {
+
+        @Test
+        @DisplayName("should call callback for valid files")
+        void shouldCallCallbackForValidFiles() throws IOException {
+            File validFile = createTempFile("config.properties");
+            Transferable transferable = createFileTransferable(Arrays.asList(validFile));
+            TransferSupport support = new TransferSupport(new JPanel(), transferable);
+
+            boolean result = handler.importData(support);
+
+            assertTrue(result);
+            assertEquals(1, openedFiles.size());
+            assertEquals(validFile, openedFiles.get(0));
+        }
+
+        @Test
+        @DisplayName("should call callback for multiple valid files")
+        void shouldCallCallbackForMultipleValidFiles() throws IOException {
+            File file1 = createTempFile("config.properties");
+            File file2 = createTempFile("settings.yaml");
+            File file3 = createTempFile("data.yml");
+            Transferable transferable = createFileTransferable(Arrays.asList(file1, file2, file3));
+            TransferSupport support = new TransferSupport(new JPanel(), transferable);
+
+            boolean result = handler.importData(support);
+
+            assertTrue(result);
+            assertEquals(3, openedFiles.size());
+        }
+
+        @Test
+        @DisplayName("should return false when no valid files")
+        void shouldReturnFalseWhenNoValidFiles() throws IOException {
+            File invalidFile = createTempFile("readme.txt");
+            Transferable transferable = createFileTransferable(Arrays.asList(invalidFile));
+            TransferSupport support = new TransferSupport(new JPanel(), transferable);
+
+            boolean result = handler.importData(support);
+
+            assertFalse(result);
+            assertTrue(openedFiles.isEmpty());
+        }
+
+        @Test
+        @DisplayName("should return false for unsupported flavor")
+        void shouldReturnFalseForUnsupportedFlavor() {
+            Transferable transferable = new StringSelection("not a file");
+            TransferSupport support = new TransferSupport(new JPanel(), transferable);
+
+            boolean result = handler.importData(support);
+
+            assertFalse(result);
+            assertTrue(openedFiles.isEmpty());
+        }
+    }
+
+    private File createTempFile(String name) throws IOException {
+        File file = new File(tempDir, name);
+        file.createNewFile();
+        return file;
+    }
+
+    private Transferable createFileTransferable(List<File> files) {
+        return new Transferable() {
+            @Override
+            public DataFlavor[] getTransferDataFlavors() {
+                return new DataFlavor[] { DataFlavor.javaFileListFlavor };
+            }
+
+            @Override
+            public boolean isDataFlavorSupported(DataFlavor flavor) {
+                return DataFlavor.javaFileListFlavor.equals(flavor);
+            }
+
+            @Override
+            public Object getTransferData(DataFlavor flavor) throws UnsupportedFlavorException {
+                if (!isDataFlavorSupported(flavor)) {
+                    throw new UnsupportedFlavorException(flavor);
+                }
+                return files;
+            }
+        };
+    }
+}


### PR DESCRIPTION
## Summary
- Implements drag and drop support for opening .properties, .yaml, and .yml files
- Files can be dropped anywhere on the application window to open them
- Automatically parses dropped files and displays them in new tabs

## Changes
- New `FileDropHandler` class extending `TransferHandler` for handling file drops
- Added `setupDragAndDrop()` method in `MainFrame` to configure the drop handler
- Fixed PMD violations in `EnvironmentsHandler` for log message formatting

## Test plan
- [x] Unit tests for `FileDropHandler` (17 tests)
- [x] Integration tests for file drop functionality (7 tests)
- [x] Verify single file drop creates a new tab
- [x] Verify multiple files drop creates multiple tabs
- [x] Verify invalid extensions (.txt, .json, etc.) are filtered out
- [x] Verify dropped files are automatically parsed
- [x] Run full build with `mvn verify`

Closes #7